### PR TITLE
CD-2724 Bump cattrs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -78,19 +78,29 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "cattrs"
-version = "22.2.0"
+version = "23.1.2"
 description = "Composable complex class support for attrs and dataclasses."
 category = "main"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "cattrs-22.2.0-py3-none-any.whl", hash = "sha256:bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21"},
-    {file = "cattrs-22.2.0.tar.gz", hash = "sha256:f0eed5642399423cf656e7b66ce92cdc5b963ecafd041d1b24d136fdde7acf6d"},
+    {file = "cattrs-23.1.2-py3-none-any.whl", hash = "sha256:b2bb14311ac17bed0d58785e5a60f022e5431aca3932e3fc5cc8ed8639de50a4"},
+    {file = "cattrs-23.1.2.tar.gz", hash = "sha256:db1c821b8c537382b2c7c66678c3790091ca0275ac486c76f3c8f3920e83c657"},
 ]
 
 [package.dependencies]
 attrs = ">=20"
 exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
+typing_extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+bson = ["pymongo (>=4.2.0,<5.0.0)"]
+cbor2 = ["cbor2 (>=5.4.6,<6.0.0)"]
+msgpack = ["msgpack (>=1.0.2,<2.0.0)"]
+orjson = ["orjson (>=3.5.2,<4.0.0)"]
+pyyaml = ["PyYAML (>=6.0,<7.0)"]
+tomlkit = ["tomlkit (>=0.11.4,<0.12.0)"]
+ujson = ["ujson (>=5.4.0,<6.0.0)"]
 
 [[package]]
 name = "cfgv"
@@ -752,6 +762,18 @@ files = [
 ]
 
 [[package]]
+name = "typing-extensions"
+version = "4.6.3"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "typing_extensions-4.6.3-py3-none-any.whl", hash = "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26"},
+    {file = "typing_extensions-4.6.3.tar.gz", hash = "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"},
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.17.1"
 description = "Virtual Python Environment builder"
@@ -778,4 +800,4 @@ pgcopy = ["cattrs"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "8b7a7536ecb9eb5a0bec65f010e605db54bf2e190b37a363e4d1faa80e50b60a"
+content-hash = "958ba9f7e0f747b5d5b8b5b95e47db5d7556f693054419cd11985debd86eeb26"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "SQL files as Python modules"
 authors = ["Václav Klusák <vaclav.klusak@maptiler.com>"]
 
 [tool.poetry.dependencies]
-cattrs = { version = "^22.2", optional = true }
+cattrs = { version = "^23.1", optional = true }
 psycopg2-binary = "^2.8"
 python = "^3.10"
 SQLAlchemy = "^1.4"


### PR DESCRIPTION
This package needs to be updated as well

Upgrading packages in cloud repository produces:
```
debian@d42ba073f9d7:/workspace$ poetry update cattrs 
Updating dependencies
Resolving dependencies... (0.8s)

Because sqlelixir[pgcopy] (2.10) @ git+https://github.com/klokan/sqlelixir.git@v2.12 depends on cattrs (^22.2)
 and maptiler-cloud depends on cattrs (^23.1.2), sqlelixir is forbidden.
So, because maptiler-cloud depends on sqlelixir[pgcopy] (2.10) @ git+https://github.com/klokan/sqlelixir.git@v2.12, version solving failed.
```